### PR TITLE
Add AppleScript way of exiting terminal Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,13 @@ In `vi`:
 :!sudo reboot
 ```
 
+## The AppleScript way
+Credit: @dbalatero
+In Mac terminal `vi`:
+
+Replace "iTerm" with your terminal application of choice:
+
+```
+:let script="activate application \"iTerm\"\ntell application \"System Events\"\n  keystroke \":\"\n  keystroke \"q\"\n  keystroke \"a\"\n  keystroke \"!\"\n  key code 36\nend tell" | call writefile(split(script, "\n", 1), '/tmp/exit-vim.scpt', 'b') | !osascript /tmp/exit-vim.scpt
+```
+


### PR DESCRIPTION
This exits Vim in iTerm2 (or your terminal app of choice) via AppleScript